### PR TITLE
agregar vista principal del feed

### DIFF
--- a/app/views/publicacion/feed.php
+++ b/app/views/publicacion/feed.php
@@ -130,6 +130,6 @@ ob_start();
 
 <?php
 $content = ob_get_clean();
-$titulo  = 'Feed';
+$titulo  = $titulo ?? 'Feed';
 require_once APP_PATH . '/views/layouts/main.php';
 ?>

--- a/app/views/publicacion/feed.php
+++ b/app/views/publicacion/feed.php
@@ -111,13 +111,12 @@ ob_start();
                 </div>
 
                 <div class="post-meta">
-                    📅 <?= htmlspecialchars($publicacion['fecha'] ?? $publicacion['Fecha_Publicacion'] ?? '', ENT_QUOTES, 'UTF-8') ?>
-                </div>
+                     <span role="img" aria-label="Fecha">📅</span> <?= htmlspecialchars($publicacion['Fecha_Publicacion'] ?? '', ENT_QUOTES, 'UTF-8') ?>                </div>
 
                 <div class="post-meta mt-2">
-                    ❤️ <?= htmlspecialchars($publicacion['reacciones'] ?? '0', ENT_QUOTES, 'UTF-8') ?>
+                    <span role="img" aria-label="Reacciones">❤️</span> <?= htmlspecialchars($publicacion['reacciones'] ?? '0', ENT_QUOTES, 'UTF-8') ?>
                     ·
-                    💬 <?= htmlspecialchars($publicacion['comentarios'] ?? '0', ENT_QUOTES, 'UTF-8') ?>
+                    <span role="img" aria-label="Comentarios">💬</span> <?= htmlspecialchars($publicacion['comentarios'] ?? '0', ENT_QUOTES, 'UTF-8') ?>
                 </div>
 
             </div>

--- a/app/views/publicacion/feed.php
+++ b/app/views/publicacion/feed.php
@@ -1,0 +1,135 @@
+<?php
+ob_start();
+?>
+
+<style>
+    .feed-wrap {
+        max-width: 760px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+    }
+
+    .feed-title {
+        font-family: 'Fraunces', serif;
+        font-size: 2rem;
+        font-weight: 700;
+        margin-bottom: 1.5rem;
+        color: var(--pb-text);
+    }
+
+    .feed-empty {
+        background: var(--pb-surface);
+        border: 1px solid var(--pb-border);
+        border-radius: var(--pb-radius);
+        padding: 4rem 2rem;
+        text-align: center;
+    }
+
+    .feed-empty-icon {
+        font-size: 4rem;
+        color: var(--pb-violet);
+        margin-bottom: 1rem;
+    }
+
+    .feed-empty-title {
+        font-size: 1.35rem;
+        font-weight: 600;
+        color: var(--pb-text);
+        margin-bottom: .5rem;
+    }
+
+    .feed-empty-subtitle {
+        color: var(--pb-muted);
+        font-size: .95rem;
+    }
+
+    .post-card {
+        background: var(--pb-surface);
+        border: 1px solid var(--pb-border);
+        border-radius: var(--pb-radius);
+        padding: 1.25rem;
+        margin-bottom: 1rem;
+    }
+
+    .post-type {
+        color: var(--pb-violet);
+        font-weight: 600;
+        font-size: .9rem;
+    }
+
+    .post-pet {
+        font-size: 1.1rem;
+        font-weight: 600;
+        margin: .4rem 0;
+    }
+
+    .post-meta {
+        color: var(--pb-muted);
+        font-size: .9rem;
+    }
+</style>
+
+<div class="feed-wrap">
+
+    <h1 class="feed-title">
+        <?= htmlspecialchars($titulo ?? 'Feed', ENT_QUOTES, 'UTF-8') ?>
+    </h1>
+
+    <?php if (empty($publicaciones)): ?>
+
+        <div class="feed-empty">
+            <div class="feed-empty-icon">
+                <i class="bi bi-chat-heart"></i>
+            </div>
+
+            <div class="feed-empty-title">
+                Todavía no hay publicaciones
+            </div>
+
+            <div class="feed-empty-subtitle">
+                Cuando los usuarios comiencen a compartir eventos y mascotas,
+                aparecerán aquí.
+            </div>
+        </div>
+
+    <?php else: ?>
+
+        <?php foreach ($publicaciones as $publicacion): ?>
+
+            <div class="post-card">
+
+                <div class="post-type">
+                    <?= htmlspecialchars($publicacion['tipo_evento'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+                </div>
+
+                <div class="post-pet">
+                    <?= htmlspecialchars($publicacion['nombre_mascota'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+                </div>
+
+                <div class="post-meta">
+                    📍 <?= htmlspecialchars($publicacion['ubicacion'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+                </div>
+
+                <div class="post-meta">
+                    📅 <?= htmlspecialchars($publicacion['fecha'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+                </div>
+
+                <div class="post-meta mt-2">
+                    ❤️ <?= htmlspecialchars($publicacion['reacciones'] ?? '0', ENT_QUOTES, 'UTF-8') ?>
+                    ·
+                    💬 <?= htmlspecialchars($publicacion['comentarios'] ?? '0', ENT_QUOTES, 'UTF-8') ?>
+                </div>
+
+            </div>
+
+        <?php endforeach; ?>
+
+    <?php endif; ?>
+
+</div>
+
+<?php
+$content = ob_get_clean();
+$titulo  = 'Feed';
+require_once APP_PATH . '/views/layouts/main.php';
+?>

--- a/app/views/publicacion/feed.php
+++ b/app/views/publicacion/feed.php
@@ -111,7 +111,7 @@ ob_start();
                 </div>
 
                 <div class="post-meta">
-                    📅 <?= htmlspecialchars($publicacion['fecha'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+                    📅 <?= htmlspecialchars($publicacion['fecha'] ?? $publicacion['Fecha_Publicacion'] ?? '', ENT_QUOTES, 'UTF-8') ?>
                 </div>
 
                 <div class="post-meta mt-2">


### PR DESCRIPTION
Implementación de la vista del feed en app/views/publicacion/feed.php:

- Se sigue el mockup definido en #2.
- Disposición general cargada con main.php como layout (ob_start / ob_get_clean).
- Variables CSS respetadas (--pb-violet, --pb-surface, --pb-border).
- Uso de clases de Bootstrap 5 ya incluidas en el layout.
- PHP limitado a condicionales simples, foreach y htmlspecialchars().
- Estado vacío: ícono, título y subtítulo cuando $publicaciones está vacío.

Este PR agrega la vista completa del feed con la estructura y estilo definidos.
